### PR TITLE
Corregir explicación de box-sizing

### DIFF
--- a/css/css-modelo-caja.html
+++ b/css/css-modelo-caja.html
@@ -95,7 +95,7 @@
     <p class="mcl-svg-figura">
       <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="830" viewBox="-40 -85 830 280" font-family="sans-serif" font-size="18">
         <title>Modelo de caja CSS "clásico"</title>
-        <text x="-30" y="-70" text-anchor="start" font-size="16pt">Modelo de caja CSS "clásico" (<tspan class="css-prop">box-sizing</tspan>: <tspan class="css-valor">border-box</tspan>)</text>
+        <text x="-30" y="-70" text-anchor="start" font-size="16pt">Modelo de caja CSS "clásico" (<tspan class="css-prop">box-sizing</tspan>: <tspan class="css-valor">content-box</tspan>)</text>
 
         <rect x="-30" y="-30" width="414" height="218" fill="none" stroke="black" stroke-width="1" stroke-dasharray="5 5" />
         <rect x="0" y="0" width="354" height="158" fill="hsl(180, 50%, 80%)" stroke="hsl(0, 100%, 50%)" stroke-width="10" />
@@ -134,7 +134,7 @@
     <p class="mcl-svg-figura">
       <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="830" viewBox="-40 -85 830 280" font-family="sans-serif" font-size="18">
         <title>Modelo de caja CSS "clásico"</title>
-        <text x="-30" y="-70" text-anchor="start" font-size="16pt">Modelo de caja CSS "alternativo" (<tspan class="css-prop">box-sizing</tspan>: <tspan class="css-valor">content-box</tspan>)</text>
+        <text x="-30" y="-70" text-anchor="start" font-size="16pt">Modelo de caja CSS "alternativo" (<tspan class="css-prop">box-sizing</tspan>: <tspan class="css-valor">border-box</tspan>)</text>
 
         <rect x="-30" y="-30" width="414" height="218" fill="none" stroke="black" stroke-width="1" stroke-dasharray="5 5" />
         <rect x="0" y="0" width="354" height="158" fill="hsl(180, 50%, 80%)" stroke="hsl(0, 100%, 50%)" stroke-width="10" />
@@ -179,7 +179,7 @@
     <ul>
       <li>en el primer ejemplo el borde se dibuja por fuera del tamaño definido para el elemento</li>
       <li>en el segundo, el borde se dibuja por dentro del tamaño definido para el elemento</li>
-      <li>en el tercero, se observa como el comportamiento predeterminado de los navegadores es el correspondiente a <span class="css-valor">border-box</span></li>
+      <li>en el tercero, se observa como el comportamiento predeterminado de los navegadores es el correspondiente a <span class="css-valor">content-box</span></li>
     </ul>
     <div class="filaflex">
       <div class="codigo">
@@ -187,7 +187,7 @@
 <code class="language-css">p {
   width: 200px;
   height: 100px;
-  <span class="codigo-resaltado">box-sizing: border-box;</span>
+  <span class="codigo-resaltado">box-sizing: content-box;</span>
   border: red 25px solid;
 }</code>
 </pre>
@@ -206,7 +206,7 @@
 <code class="language-css">p {
   width: 200px;
   height: 100px;
-  <span class="codigo-resaltado">box-sizing: content-box;</span>
+  <span class="codigo-resaltado">box-sizing: border-box;</span>
   border: red 25px solid;
 }</code>
 </pre>


### PR DESCRIPTION
Las explicaciones de box-sizing están alrevés. Corrección para que el texto se corresponda con el box-sizing correcto.